### PR TITLE
Implement #2

### DIFF
--- a/script.js
+++ b/script.js
@@ -105,6 +105,12 @@ function handlePercent() {
   updateDisplay(state.current);
 }
 
+function handleBackspace() {
+  if (state.justEvaluated || state.waitingForOperand) return;
+  state.current = state.current.length > 1 ? state.current.slice(0, -1) : '0';
+  updateDisplay(state.current);
+}
+
 document.querySelector('.calc-keys').addEventListener('click', function(e) {
   const btn = e.target.closest('.key');
   if (!btn) return;
@@ -130,4 +136,5 @@ document.addEventListener('keydown', function(e) {
   if (e.key === 'Enter' || e.key === '=') { handleEquals(); return; }
   if (e.key === 'Escape') { handleAC(); return; }
   if (e.key === '%') { handlePercent(); return; }
+  if (e.key === 'Backspace') { handleBackspace(); return; }
 });


### PR DESCRIPTION
Closes #2

## Changes
- Added `handleBackspace()` function to remove the last digit (or reset to `0` if single char)
- Added `Backspace` key handler in the keyboard event listener

## Acceptance Criteria
- [x] `9 + 3 - 2 =` shows `10` — chained operations already worked correctly via state machine
- [x] `5 / 0 =` shows `DIV/0` in magenta — error handling + CSS `.error` class already in place
- [x] Typing `1.2.3` only shows `1.23` — double decimal guard already in `handleNumber()`
- [x] Pressing `Backspace` removes the last digit — **added in this PR**
- [x] All keyboard shortcuts work (0-9, `.`, `+`, `-`, `*`, `/`, `Enter`, `Escape`, `%`, `Backspace`) — Backspace was the missing one
- [x] No console errors during any operation