### PR TITLE
Implement #3

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#0a0a0f" />
   <title>CYBERPUNK CALC</title>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+PHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiBmaWxsPSIjMGEwYTBmIi8+PHJlY3QgeD0iNCIgeT0iMTQiIHdpZHRoPSI4IiBoZWlnaHQ9IjQiIHJ4PSIxIiBmaWxsPSJub25lIiBzdHJva2U9IiMwMGZmZmYiIHN0cm9rZS13aWR0aD0iMS41Ii8+PHJlY3QgeD0iMjAiIHk9IjE0IiB3aWR0aD0iOCIgaGVpZ2h0PSI0IiByeD0iMSIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMDBmZmZmIiBzdHJva2Utd2lkdGg9IjEuNSIvPjxsaW5lIHgxPSIxMiIgeTE9IjE2IiB4Mj0iMjAiIHkyPSIxNiIgc3Ryb2tlPSIjMDBmZmZmIiBzdHJva2Utd2lkdGg9IjEuNSIvPjxjaXJjbGUgY3g9IjE2IiBjeT0iOCIgcj0iMiIgZmlsbD0iI2ZmMDBmZiIvPjxsaW5lIHgxPSIxNiIgeTE9IjEwIiB4Mj0iMTYiIHkyPSIxNCIgc3Ryb2tlPSIjZmYwMGZmIiBzdHJva2Utd2lkdGg9IjEuNSIvPjxjaXJjbGUgY3g9IjE2IiBjeT0iMjQiIHI9IjIiIGZpbGw9IiMwMGZmNDEiLz48bGluZSB4MT0iMTYiIHkxPSIyMiIgeDI9IjE2IiB5Mj0iMTgiIHN0cm9rZT0iIzAwZmY0MSIgc3Ryb2tlLXdpZHRoPSIxLjUiLz48L3N2Zz4=" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@
 
 const display = document.getElementById('display');
 const expression = document.getElementById('expression');
+const calcDisplay = document.querySelector('.calc-display');
 
 const state = {
   current: '0',
@@ -85,6 +86,10 @@ function handleEquals() {
   state.operand = null;
   state.waitingForOperand = false;
   state.justEvaluated = true;
+  calcDisplay.classList.remove('flash');
+  void calcDisplay.offsetWidth;
+  calcDisplay.classList.add('flash');
+  calcDisplay.addEventListener('animationend', () => calcDisplay.classList.remove('flash'), { once: true });
 }
 
 function handleAC() {

--- a/script.js
+++ b/script.js
@@ -19,6 +19,8 @@ function updateDisplay(val) {
 
 function showError(msg) {
   display.textContent = msg;
+  display.classList.remove('error');
+  void display.offsetWidth;
   display.classList.add('error');
   expression.textContent = '';
   Object.assign(state, { current: '0', operator: null, operand: null, waitingForOperand: false, justEvaluated: false });

--- a/script.js
+++ b/script.js
@@ -114,6 +114,10 @@ function handleBackspace() {
 document.querySelector('.calc-keys').addEventListener('click', function(e) {
   const btn = e.target.closest('.key');
   if (!btn) return;
+  btn.classList.remove('pressed');
+  void btn.offsetWidth;
+  btn.classList.add('pressed');
+  btn.addEventListener('animationend', () => btn.classList.remove('pressed'), { once: true });
   const action = btn.dataset.action;
   const value = btn.dataset.value;
   if (value !== undefined) { handleNumber(value); return; }

--- a/styles.css
+++ b/styles.css
@@ -130,7 +130,19 @@ body {
 
 .calc-display.flash { animation: screen-flash 0.4s ease-out; }
 
-.calc-screen.error { color: var(--magenta); text-shadow: var(--glow-magenta); }
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20%  { transform: translateX(-6px); }
+  40%  { transform: translateX(6px); }
+  60%  { transform: translateX(-4px); }
+  80%  { transform: translateX(4px); }
+}
+
+.calc-screen.error {
+  color: var(--magenta);
+  text-shadow: var(--glow-magenta);
+  animation: shake 0.4s ease-out;
+}
 
 .calc-keys {
   display: grid;

--- a/styles.css
+++ b/styles.css
@@ -145,6 +145,14 @@ body {
 
 .key:active { transform: scale(0.93); }
 
+@keyframes key-press-glow {
+  0%   { box-shadow: 0 0 0px transparent; }
+  40%  { box-shadow: 0 0 14px #00ffff, 0 0 28px #00ffff66; }
+  100% { box-shadow: 0 0 0px transparent; }
+}
+
+.key.pressed { animation: key-press-glow 0.35s ease-out forwards; }
+
 .key-fn {
   background: var(--key-fn);
   color: var(--cyan);

--- a/styles.css
+++ b/styles.css
@@ -122,6 +122,14 @@ body {
   0%, 100% { opacity: 1; }
   50% { opacity: 0; }
 }
+@keyframes screen-flash {
+  0%   { background: transparent; }
+  30%  { background: rgba(0, 255, 255, 0.12); }
+  100% { background: transparent; }
+}
+
+.calc-display.flash { animation: screen-flash 0.4s ease-out; }
+
 .calc-screen.error { color: var(--magenta); text-shadow: var(--glow-magenta); }
 
 .calc-keys {


### PR DESCRIPTION
Closes #3

## Changes

- **Step 1**: Added `@keyframes key-press-glow` and `.key.pressed` CSS class; JS adds/removes the class on each button click for a brief neon glow flash
- **Step 2**: Added `@keyframes screen-flash` and `.calc-display.flash` class; triggered in `handleEquals()` for a quick cyan flash on the display
- **Step 3**: Added `@keyframes shake` to `.calc-screen.error`; force-reflows in `showError()` to re-trigger animation on repeated errors
- **Step 4**: Added `<meta name="theme-color" content="#0a0a0f">` to `index.html` for mobile browser chrome theming
- **Step 5**: Added base64 inline SVG favicon (neon circuit icon) to `index.html`

## Acceptance Criteria

- [x] Clicking any button produces a brief neon glow flash
- [x] Pressing `=` triggers a quick screen flash animation
- [x] Error state shows a shake animation
- [x] Mobile browser chrome matches the dark theme color
- [x] No console errors
- [x] App passes smoke test: loads, no console errors